### PR TITLE
fixed annotation pins for Retina displays

### DIFF
--- a/ZSPinAnnotation.m
+++ b/ZSPinAnnotation.m
@@ -33,7 +33,7 @@
 	UIImage *stick = [UIImage imageNamed:@"stick.png"];
 	
 	// Start new graphcs context
-	UIGraphicsBeginImageContext(stick.size);
+	UIGraphicsBeginImageContextWithOptions(stick.size, NO, [[UIScreen mainScreen] scale]);
 	
 	CGRect rectFull = CGRectMake(0, 0, stick.size.width, stick.size.height);
 	
@@ -68,7 +68,7 @@
 	UIImage *img = [UIImage imageNamed:@"color.png"];
 	
 	// begin a new image context, to draw our colored image onto
-    UIGraphicsBeginImageContext(img.size);
+	UIGraphicsBeginImageContextWithOptions(img.size, NO, [[UIScreen mainScreen] scale]);
     
     // get a reference to that context we created
     CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
- changed calls to UIGraphicsBeginImageContext() to calls to UIGraphicsBeginImageContextWithOptions(), allowing the specification of the screen scale. This allows the annotation pins to be drawn properly on Retina displays.
