### PR TITLE
fixed comparison value

### DIFF
--- a/ZSPinAnnotation/src/ZSPinAnnotation.m
+++ b/ZSPinAnnotation/src/ZSPinAnnotation.m
@@ -86,7 +86,7 @@
         typeName = @"_disc";
     } else if (type == ZSPinAnnotationTypeTag) {
         typeName = @"_tag";
-    } else if (type == ZSPinAnnotationTypeTag) {
+    } else if (type == ZSPinAnnotationTypeTagStroke) {
         typeName = @"_tagStroke";
     }
     


### PR DESCRIPTION
prevents mixing up cached images of different ZSPinAnnotationTypes